### PR TITLE
Add dynamic README with repo list

### DIFF
--- a/.github/workflows/update-readme.yml
+++ b/.github/workflows/update-readme.yml
@@ -1,0 +1,31 @@
+name: Update README
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 0 * * *'
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - name: Set up Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.x'
+      - name: Install dependencies
+        run: pip install -r requirements.txt
+      - name: Update README
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: python update_readme.py
+      - name: Commit changes
+        run: |
+          git config user.name 'GitHub Actions'
+          git config user.email 'actions@github.com'
+          git add README.md
+          if git diff --cached --quiet; then
+            echo 'No changes to commit'
+          else
+            git commit -m 'chore: update README with repo list'
+            git push
+          fi

--- a/README.md
+++ b/README.md
@@ -1,5 +1,35 @@
-# Arbuzov Profile
+# Сергей Арбузов
 
-This repository contains my GitHub profile README as well as a simple business card website. The site is located in the `docs` folder so it can be served with GitHub Pages.
+Привет! Я разработчик. Это мой персональный репозиторий профиля.
 
-You can view the page by enabling GitHub Pages in the repository settings or by opening `docs/index.html` locally.
+[![GitHub Streak](https://github-readme-streak-stats.herokuapp.com/?user=Arbuzov)](https://github.com/Arbuzov)
+[![GitHub Stats](https://github-readme-stats.vercel.app/api?username=Arbuzov&show_icons=true&theme=radical)](https://github.com/Arbuzov)
+
+## Мои репозитории
+
+<!--START_REPOS-->
+- [Arbuzov](https://github.com/Arbuzov/Arbuzov)
+- [mcp-atlassian-helm](https://github.com/Arbuzov/mcp-atlassian-helm)
+- [hass-broadlink-ac-mqtt](https://github.com/Arbuzov/hass-broadlink-ac-mqtt)
+- [home_assistant_delonghi_primadonna](https://github.com/Arbuzov/home_assistant_delonghi_primadonna)
+- [home_assistant_xiaomi_tv](https://github.com/Arbuzov/home_assistant_xiaomi_tv)
+- [home_assistant_oiot](https://github.com/Arbuzov/home_assistant_oiot)
+- [compose-web-manager](https://github.com/Arbuzov/compose-web-manager)
+- [home_assistant_smart_curtain](https://github.com/Arbuzov/home_assistant_smart_curtain)
+- [hass-guacamole](https://github.com/Arbuzov/hass-guacamole)
+- [SmartCurtainBLE](https://github.com/Arbuzov/SmartCurtainBLE)
+- [SmartCurtainWiFi](https://github.com/Arbuzov/SmartCurtainWiFi)
+- [pan-tilt-lab](https://github.com/Arbuzov/pan-tilt-lab)
+- [elasticsearch_jenkins_pipeline](https://github.com/Arbuzov/elasticsearch_jenkins_pipeline)
+- [arbuzov.github.io](https://github.com/Arbuzov/arbuzov.github.io)
+- [jenkins-shared-library](https://github.com/Arbuzov/jenkins-shared-library)
+- [Travel](https://github.com/Arbuzov/Travel)
+- [jenkins-php-checknode](https://github.com/Arbuzov/jenkins-php-checknode)
+- [selenium-package](https://github.com/Arbuzov/selenium-package)
+- [ant-github](https://github.com/Arbuzov/ant-github)
+<!--END_REPOS-->
+
+## Контакты
+
+- [Сайт визитка](https://arbuzov.github.io/)
+- [info@whitediver.com](mailto:info@whitediver.com)

--- a/docs/index.html
+++ b/docs/index.html
@@ -14,6 +14,7 @@
         <p><a href="mailto:info@whitediver.com">info@whitediver.com</a></p>
         <div class="links">
             <a href="https://github.com/Arbuzov">GitHub</a>
+            <a href="https://github.com/Arbuzov/Arbuzov">README</a>
         </div>
     </div>
 </body>

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,1 @@
+requests

--- a/update_readme.py
+++ b/update_readme.py
@@ -1,0 +1,56 @@
+import os
+import requests
+
+START = "<!--START_REPOS-->"
+END = "<!--END_REPOS-->"
+
+def fetch_repos(token=None):
+    headers = {}
+    login = os.getenv("GITHUB_USER")
+    if token:
+        headers["Authorization"] = f"token {token}"
+        user = requests.get("https://api.github.com/user", headers=headers)
+        user.raise_for_status()
+        login = user.json()["login"]
+    elif not login:
+        raise SystemExit("GITHUB_USER environment variable required when no token provided")
+
+    repos = []
+    page = 1
+    while True:
+        r = requests.get(f"https://api.github.com/users/{login}/repos", headers=headers, params={"per_page": 100, "page": page, "sort": "updated"})
+        r.raise_for_status()
+        data = r.json()
+        if not data:
+            break
+        repos.extend([repo for repo in data if not repo.get("fork")])
+        page += 1
+    return login, repos
+
+
+def format_repo_list(repos):
+    lines = [f"- [{repo['name']}]({repo['html_url']})" for repo in repos]
+    return "\n".join(lines)
+
+
+def update_readme(repo_lines):
+    with open("README.md", "r", encoding="utf-8") as f:
+        content = f.read()
+    if START not in content or END not in content:
+        raise ValueError("README missing repo markers")
+    pre, rest = content.split(START, 1)
+    _, post = rest.split(END, 1)
+    new_content = pre + START + "\n" + repo_lines + "\n" + END + post
+    with open("README.md", "w", encoding="utf-8") as f:
+        f.write(new_content)
+
+
+def main():
+    token = os.getenv('GITHUB_TOKEN')
+    _, repos = fetch_repos(token)
+    repo_lines = format_repo_list(repos)
+    update_readme(repo_lines)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- create Python script `update_readme.py` to fetch repository list via GitHub API
- add GitHub Actions workflow to run the script daily
- update `README.md` with badges, repo list section and contact links
- update docs to link back to the README
- add requirements file for the script

## Testing
- `GITHUB_USER=Arbuzov python3 update_readme.py`
- `python3 -m py_compile update_readme.py`


------
https://chatgpt.com/codex/tasks/task_e_6870341500288320b7575159c89e2c4d

## Summary by Sourcery

Introduce a dynamic README update workflow by adding a Python script to fetch and render repository listings, scheduling it via GitHub Actions, and enriching the README and docs with badges, repo list, and navigation links.

New Features:
- Add a Python script to fetch user repositories from the GitHub API and inject them into the README.
- Add a GitHub Actions workflow to run the update script daily or on demand.

Enhancements:
- Update README.md to include GitHub streak and stats badges, a dynamic “My repositories” section, and contact links.
- Add a link from the docs index back to the main README for navigation.

Build:
- Add a requirements.txt listing the requests dependency for the update script.